### PR TITLE
Flip grid before printing in render so it prints correctly.

### DIFF
--- a/gym_lattice/envs/lattice2d_env.py
+++ b/gym_lattice/envs/lattice2d_env.py
@@ -247,7 +247,8 @@ class Lattice2DEnv(gym.Env):
         """Renders the environment"""
 
         outfile = StringIO() if mode == 'ansi' else sys.stdout
-        desc = self.grid.astype(str)
+        # Flip so highest y-value row is printed first
+        desc = np.flipud(self.grid).astype(str)
 
         # Convert everything to human-readable symbols
         desc[desc == '0'] = '*'


### PR DESCRIPTION
Fixes #22 
New output (down now moves down as expected):

```
  (Left)
***********
***********
***********
***********
***********
****HH*****
***********
***********
***********
***********
***********
  (Right)
***********
***********
***********
***********
***********
****HH*****
***********
***********
***********
***********
***********
  (Down)
***********
***********
***********
***********
***********
****HH*****
****P******
***********
***********
***********
***********
```